### PR TITLE
Added localhost as returned host on socket:// configuration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function(remote) {
   if (protocol === 'tcp') protocol = 'http'
   if (host[0] === '/') protocol = 'unix'
 
-  if (protocol === 'unix' || protocol === 'http+unix') return {socketPath:host, protocol:'http:'}
+  if (protocol === 'unix' || protocol === 'http+unix') return {socketPath:host, host:'localhost', protocol:'http:'}
   if (host === '0.0.0.0') host = 'localhost'
   return {host:host, port:parseInt(port, 10), protocol:protocol+':'}
 }

--- a/test.js
+++ b/test.js
@@ -22,16 +22,15 @@ tape('0.0.0.0', function(t) {
 })
 
 tape('unix', function(t) {
-  t.same(host('unix:///foo.sock'), {socketPath:'/foo.sock', protocol:'http:'})
-  t.same(host('/foo.sock'), {socketPath:'/foo.sock', protocol:'http:'})
+  t.same(host('unix:///foo.sock'), {socketPath:'/foo.sock', host:'localhost', protocol:'http:'})
+  t.same(host('/foo.sock'), {socketPath:'/foo.sock', host:'localhost', protocol:'http:'})
   t.end()
 })
 
 tape('env', function(t) {
   process.env.DOCKER_HOST = ''
-  t.same(host(), {socketPath:'/var/run/docker.sock', protocol:'http:'})
+  t.same(host(), {socketPath:'/var/run/docker.sock', host:'localhost', protocol:'http:'})
   process.env.DOCKER_HOST = 'unix:///env.sock'
-  t.same(host(), {socketPath:'/env.sock', protocol:'http:'})
+  t.same(host(), {socketPath:'/env.sock', host:'localhost', protocol:'http:'})
   t.end()
 })
-


### PR DESCRIPTION
When running on Linux, Docker by default uses a `socket://` connection. Anyway, it's still `localhost`.

This pull request adds the feature that `docker-host` also returns `host: 'localhost'` for a `socket://` configuration. This is useful, e.g. if you run MongoDB on Docker on Linux, and want to access the server at the same host that Docker runs.

So far, this was not possible, so you ended up with something such as:

``` javascript
const mongoHost = dockerHost.host || 'localhost';
```

What do you think about this?
